### PR TITLE
Chance for loaded guns in monster_drops

### DIFF
--- a/data/json/monster_drops.json
+++ b/data/json/monster_drops.json
@@ -27,12 +27,26 @@
             [ "tools", 20 ],
             [ "trash", 7 ],
             [ "ammo", 1 ],
-            [ "pistols", 1 ],
-            [ "shotguns", 1 ],
-            [ "smg", 1 ],
             [ "home_hw", 5 ],
             [ "postman_gear", 5]
-        ]
+        ],
+		"entries": [
+			{ "distribution": [
+				{"group": "pistols", "charges-min": 5, "charges-max": 30, "prob": 1 },
+				{"group": "pistols", "charges-min": 0, "charges-max": 5, "prob": 2 },
+				{"group": "pistols", "prob": 9 }
+			], "prob": 1 },
+			{ "distribution": [
+				{"group": "shotguns", "charges-min": 5, "charges-max": 30, "prob": 1 },
+				{"group": "shotguns", "charges-min": 0, "charges-max": 5, "prob": 2 },
+				{"group": "shotguns", "prob": 9 }
+			], "prob": 1 },
+			{ "distribution": [
+				{"group": "smg", "charges-min": 10, "charges-max": 50, "prob": 1 },
+				{"group": "smg", "charges-min": 0, "charges-max": 10, "prob": 2 },
+				{"group": "smg", "prob": 9 }
+			], "prob": 1 }
+		]
     },
     {
         "type" : "item_group",
@@ -117,12 +131,28 @@
             { "group": "underwear", "damage-min": 1, "damage-max": 4 },
             { "distribution": [
                 { "group": "ammo", "prob": 10 },
-                { "group": "pistols", "prob": 5 },
-                { "group": "shotguns", "prob": 2 },
-                { "group": "smg", "prob": 5 },
+				{ "distribution": [
+					{"group": "pistols", "charges-min": 5, "charges-max": 30, "prob": 1 },
+					{"group": "pistols", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "pistols", "prob": 6 }
+				], "prob": 5 },				
+				{ "distribution": [
+					{"group": "shotguns", "charges-min": 5, "charges-max": 30, "prob": 1 },
+					{"group": "shotguns", "charges-min": 0, "charges-max": 5, "prob": 2 },
+					{"group": "shotguns", "prob": 6 }
+				], "prob": 2 },
+				{ "distribution": [
+					{"group": "smg", "charges-min": 10, "charges-max": 50, "prob": 1 },
+					{"group": "smg", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "smg", "prob": 6 }
+				], "prob": 5 },
                 { "group": "bots", "prob": 1 },
                 { "group": "launchers", "prob": 2 },
-                { "group": "mil_rifles", "prob": 10 },
+				{ "distribution": [
+					{"group": "mil_rifles", "charges-min": 10, "charges-max": 50, "prob": 1 },
+					{"group": "mil_rifles", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "mil_rifles", "prob": 6 }
+				], "prob": 10 },
                 { "group": "grenades", "prob": 5 },
                 { "group": "mil_accessories", "prob": 10 },
                 { "group": "mil_food", "prob": 5 },
@@ -182,11 +212,27 @@
             { "group": "underwear", "damage-min": 1, "damage-max": 4 },
             { "distribution": [
                 { "group": "ammo", "prob": 15 },
-                { "group": "pistols", "prob": 5 },
-                { "group": "shotguns", "prob": 4 },
-                { "group": "smg", "prob": 5 },
+				{ "distribution": [
+					{"group": "pistols", "charges-min": 5, "charges-max": 30, "prob": 1 },
+					{"group": "pistols", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "pistols", "prob": 6 }
+				], "prob": 5 },	
+				{ "distribution": [
+					{"group": "shotguns", "charges-min": 5, "charges-max": 30, "prob": 1 },
+					{"group": "shotguns", "charges-min": 0, "charges-max": 5, "prob": 2 },
+					{"group": "shotguns", "prob": 6 }
+				], "prob": 4 },
+				{ "distribution": [
+					{"group": "smg", "charges-min": 10, "charges-max": 50, "prob": 1 },
+					{"group": "smg", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "smg", "prob": 6 }
+				], "prob": 5 },
                 { "group": "bots", "prob": 1 },
-                { "group": "mil_rifles", "prob": 10 },
+				{ "distribution": [
+					{"group": "mil_rifles", "charges-min": 10, "charges-max": 50, "prob": 1 },
+					{"group": "mil_rifles", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "mil_rifles", "prob": 6 }
+				], "prob": 10 },
                 { "group": "grenades", "prob": 5 },
                 { "group": "mil_accessories", "prob": 10 },
                 { "group": "mil_food", "prob": 5 },
@@ -249,9 +295,17 @@
                 "damage-min": 1, "damage-max": 4
             },
             { "distribution": [
-                { "group": "allguns", "prob": 24 },
+				{ "distribution": [
+					{"group": "allguns", "charges-min": 30, "charges-max": 75, "prob": 1 },
+					{"group": "allguns", "charges-min": 10, "charges-max": 30, "prob": 1 },
+					{"group": "allguns", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "allguns", "prob": 12 }
+				], "prob": 24 },
                 { "group": "grenades", "prob": 10 },
-                { "group": "mil_rifles", "prob": 8 },
+				{"group": "mil_rifles", "charges-min": 10, "charges-max": 50, "prob": 1 },
+					{"group": "mil_rifles", "charges-min": 0, "charges-max": 10, "prob": 2 },
+					{"group": "mil_rifles", "prob": 9 }
+				], "prob": 8 },
                 { "group": "mil_hw", "prob": 1 },
                 { "group": "launchers", "prob": 1 },
                 { "group": "gunxtras", "prob": 14 },

--- a/data/json/monster_drops.json
+++ b/data/json/monster_drops.json
@@ -302,7 +302,8 @@
 					{"group": "allguns", "prob": 12 }
 				], "prob": 24 },
                 { "group": "grenades", "prob": 10 },
-				{"group": "mil_rifles", "charges-min": 10, "charges-max": 50, "prob": 1 },
+				{ "distribution": [
+					{"group": "mil_rifles", "charges-min": 10, "charges-max": 50, "prob": 1 },
 					{"group": "mil_rifles", "charges-min": 0, "charges-max": 10, "prob": 2 },
 					{"group": "mil_rifles", "prob": 9 }
 				], "prob": 8 },

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -182,7 +182,7 @@ void Item_modifier::modify(item &new_item) const
     long ch = (charges.first == charges.second) ? charges.first : rng(charges.first, charges.second);
     const auto g = new_item.type->gun.get();
     it_tool *t = dynamic_cast<it_tool *>(new_item.type);
-   
+
     if(ch != -1) {
         if( new_item.count_by_charges() || new_item.made_of( LIQUID ) ) {
             // food, ammo
@@ -190,16 +190,16 @@ void Item_modifier::modify(item &new_item) const
         } else if(t != NULL) {
             new_item.charges = std::min(ch, t->max_charges);
         } else if (g == nullptr){
-            //not gun, food, ammo or tool. 
+            //not gun, food, ammo or tool.
             new_item.charges = ch;
         }
     }
-    
+
     if( g != nullptr && ( ammo.get() != nullptr || ch > 0 ) ) {
         if( ammo.get() == nullptr ) {
             // In case there is no explicit ammo item defined, use the default ammo
             const auto ammoid = default_ammo( g->ammo );
-            if ( !ammoid.empty() ) {
+            if ( !ammoid.empty() && ammoid != "UPS") {
                 new_item.set_curammo( ammoid );
                 new_item.charges = ch;
             }


### PR DESCRIPTION
Added chance for gun drops to all zombies with gun drops sans police zombie. 
Currently there is a 25% chance for a regular zombie's gun to be loaded, and a 33% for a combat-oriented zombie's gun to be loaded. Amount of ammo loaded is also (crudely) weighted, with a higher amount being more rare.

TODO for future: 
Split cop weapons between those with ammo and those without
Add chance for loaded weapons on those groups of dead soldiers you sometimes find

EDIT: Fixed a typo and the UPS bug. I would advise a read-over and further testing of my code cause things get weird at 1:00 am.